### PR TITLE
Hotfix quote style on delete-table-rows handler

### DIFF
--- a/src/main/ipc-handlers/tables.js
+++ b/src/main/ipc-handlers/tables.js
@@ -188,7 +188,7 @@ export default (connections) => {
             const fieldName = Object.keys(row)[0].includes('.') ? `${params.table}.${params.primary}` : params.primary;
 
             return typeof row[fieldName] === 'string'
-               ? `"${row[fieldName]}"`
+               ? `'${row[fieldName]}'`
                : row[fieldName];
          }).join(',');
 


### PR DESCRIPTION
Use single quote as intended for ID in delete query.