### PR TITLE
Use single quotes to get the MySQL version

### DIFF
--- a/src/main/libs/clients/MySQLClient.js
+++ b/src/main/libs/clients/MySQLClient.js
@@ -1170,7 +1170,7 @@ export class MySQLClient extends AntaresCore {
     * @memberof MySQLClient
     */
    async getVersion () {
-      const sql = 'SHOW VARIABLES LIKE "%vers%"';
+      const sql = 'SHOW VARIABLES LIKE \'%vers%\'';
       const { rows } = await this.raw(sql);
 
       return rows.reduce((acc, curr) => {


### PR DESCRIPTION
MySQL 8, probably with `ANSI_QUOTES` enabled, rejects double quotes.

I just wonder if single quotes are accepted in any configuration or we need to check that before using one or the other.